### PR TITLE
fix(createHOCFromMapper): wait for `setState` before rendering

### DIFF
--- a/src/utils/createHOCFromMapper.js
+++ b/src/utils/createHOCFromMapper.js
@@ -48,7 +48,9 @@ const createComponentFromMappers = (mappers, childFactory) =>
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-      return !nextState || this.state.childProps !== nextState.childProps;
+      return nextState && (
+        !this.state || this.state.childProps !== nextState.childProps
+      );
     }
 
     render() {


### PR DESCRIPTION
This is a sequel of ba4efac which was inherently broken.