### PR TITLE
refactor(callOrUse): spare a function creation

### DIFF
--- a/src/utils/callOrUse.js
+++ b/src/utils/callOrUse.js
@@ -1,5 +1,5 @@
-export default fn => (a, b, c) => (
-  typeof fn === 'function'
-    ? fn(a, b, c)
-    : fn
+export default (fnOrObject, a, b, c) => (
+  typeof fnOrObject === 'function'
+    ? fnOrObject(a, b, c)
+    : fnOrObject
 )

--- a/src/withObs.js
+++ b/src/withObs.js
@@ -20,7 +20,7 @@ import createHelper from './createHelper'
  * }))
  */
 const withObs = obsMapper => createHOCFromMapper((props$, obs) => {
-  const nextObs = callOrUse(obsMapper)({ ...obs, props$ })
+  const nextObs = callOrUse(obsMapper, { ...obs, props$ })
   const { props$: nextProps$ = props$ } = nextObs
   delete nextObs.props$
   return [nextProps$, { ...obs, ...nextObs }]

--- a/src/withProps.js
+++ b/src/withProps.js
@@ -20,17 +20,16 @@ import updateProps from './utils/updateProps'
  * const Button = withProps({type: 'button'})('button');
  * const XButton = withProps(({type}) => {type: `x${type}`})('button');
  */
-const withProps = (propsMapper) => {
-  const propsOrMapper = callOrUse(propsMapper)
-  return createCompactableHOC(
+const withProps = propsMapper => (
+  createCompactableHOC(
     updateProps(next => (props) => {
-      next({ ...props, ...propsOrMapper(props) })
+      next({ ...props, ...callOrUse(propsMapper, props) })
     }),
     (BaseComponent) => {
       const factory = createEagerFactory(BaseComponent)
-      return props => factory({ ...props, ...propsOrMapper(props) })
+      return props => factory({ ...props, ...callOrUse(propsMapper, props) })
     },
   )
-}
+)
 
 export default createHelper(withProps, 'withProps')

--- a/src/withReducer.js
+++ b/src/withReducer.js
@@ -69,7 +69,7 @@ const withReducer = (stateName, dispatchName, reducer, initialState) =>
         initialized = true
 
         if (initialState !== undefined) {
-          updateState(callOrUse(initialState)(props))
+          updateState(callOrUse(initialState, props))
         } else {
           updateState(reducer(undefined, { type: INIT }))
         }

--- a/src/withState.js
+++ b/src/withState.js
@@ -50,7 +50,7 @@ const withState = (stateName, stateUpdaterName, initialState) =>
     let previousStateValue
 
     const updateState = (nextState) => {
-      update(previousProps, callOrUse(nextState)(previousStateValue))
+      update(previousProps, callOrUse(nextState, previousStateValue))
     }
 
     const update = (props, stateValue) => {
@@ -68,7 +68,7 @@ const withState = (stateName, stateUpdaterName, initialState) =>
       update(
         props,
         !previousProps
-          ? callOrUse(initialState)(props)
+          ? callOrUse(initialState, props)
           : previousStateValue,
       )
     }


### PR DESCRIPTION
For our purpose, it's useless to return a function from `callOrUse`.
Additionally, with the current implementation, the "callOrUse" name is a
bit confusing because `callOrUse` doesn't call nor use the provided
function or object. It just wraps it in a function.

I was initially thinking of renaming this helper to something like
`wrap` but I figured we do not actually need to "wrap" anything.

So, let's stick with the "callOrUse" name and indeed call or use
the provided function or object.