### PR TITLE
feat(core): complete props$ when unmounted

### DIFF
--- a/src/__tests__/withObs.test.js
+++ b/src/__tests__/withObs.test.js
@@ -66,6 +66,20 @@ describe('withObs', () => {
     expect(count).toBe(1)
   })
 
+  it('should complete props$ when unmounted', () => {
+    const spy = jest.fn()
+    const Component = compose(
+      withObs(({ props$ }) => ({
+        props$: props$.last().do(spy),
+      })),
+    )('div')
+
+    const wrapper = mount(<Component />)
+    expect(spy).not.toHaveBeenCalled()
+    wrapper.unmount()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
   it('should be merged with other hoc', () => {
     const Component = compose(
       withObs(() => ({})),

--- a/src/utils/createHOCFromMapper.js
+++ b/src/utils/createHOCFromMapper.js
@@ -58,6 +58,7 @@ const createComponentFromMappers = (mappers, childFactory) => {
     }
 
     componentWillUnmount() {
+      this.props$.complete()
       this.childPropsSubscription.unsubscribe()
     }
 


### PR DESCRIPTION
BREAKING CHANGE: complete is now called when a component is unmounted.

Required for #80