### PR TITLE
doc(setStatic): Wrong example documentation

### DIFF
--- a/src/setStatic.js
+++ b/src/setStatic.js
@@ -8,7 +8,7 @@
  * @returns {HigherOrderComponent} A function that takes a component and returns a new component.
  * @example
  *
- * setStatic({defaultProps: {type: 'button'}})('button');
+ * setStatic('defaultProps', { type: 'button' })('button');
  */
 const setStatic = (key, value) => BaseComponent => {
   /* eslint-disable no-param-reassign */


### PR DESCRIPTION
It currently gives the impression that it takes an object of keys, when in fact it takes a `key, value` pair